### PR TITLE
Export types added

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -21,7 +21,8 @@
 		".": {
 			"import": {
 				"node": "./dist/cjs/index.js",
-				"default": "./dist/esm/index.js"
+				"default": "./dist/esm/index.js",
+				"types": "./dist/types/index.d.ts"
 			},
 			"require": "./dist/cjs/index.js"
 		}

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -24,7 +24,8 @@
 		".": {
 			"import": {
 				"node": "./dist/cjs/index.js",
-				"default": "./dist/esm/index.js"
+				"default": "./dist/esm/index.js",
+				"types": "./dist/types/index.d.ts"
 			},
 			"require": "./dist/cjs/index.js"
 		}


### PR DESCRIPTION
Hello!

Fix for latest version typescript, to solve problem with correct importing types

"Could not find a declaration file for module '@telegram-auth/react'. '/node_modules/.pnpm/@telegram-auth+react@1.0.0_react@18.2.0/node_modules/@telegram-auth/react/dist/esm/index.js' implicitly has an 'any' type.
  There are types at '/node_modules/@telegram-auth/react/dist/types/index.d.ts', but this result could not be resolved when respecting package.json "exports". The '@telegram-auth/react' library may need to update its package.json or typings.