### PR TITLE
Refactor way of sending payload if web app data

### DIFF
--- a/.changeset/stupid-dots-hug.md
+++ b/.changeset/stupid-dots-hug.md
@@ -1,0 +1,5 @@
+---
+"@telegram-auth/server": patch
+---
+
+Refactor way of sending payload if web app data

--- a/packages/server/src/AuthDataValidator.ts
+++ b/packages/server/src/AuthDataValidator.ts
@@ -195,7 +195,7 @@ export class AuthDataValidator {
 		let data: T;
 
 		if (isWebAppData) {
-			data = authData.has('user') ? JSON.parse(authData.get('user')?.toString() || '{}') : {};
+			data = (authData.has('user') ? authData.get('user') : {}) as T;
 		} else {
 			data = Object.fromEntries(authData.entries()) as T;
 		}
@@ -289,7 +289,11 @@ export class AuthDataValidator {
 		const dataToCheck: Array<string> = [];
 
 		for (const [key, value] of authDataMap.entries()) {
-			dataToCheck.push(`${key}=${value}`);
+			if (typeof value !== 'object') {
+				dataToCheck.push(`${key}=${value}`);
+			} else {
+				dataToCheck.push(`${key}=${JSON.stringify(value)}`);
+			}
 		}
 		dataToCheck.sort();
 

--- a/packages/server/src/utils/types.ts
+++ b/packages/server/src/utils/types.ts
@@ -1,7 +1,7 @@
 /**
  * Shape of the data to be passed AuthDataValidator.validate().
  */
-export type AuthDataMap = Map<string, string | number>;
+export type AuthDataMap = Map<string, string | number | object>;
 
 /**
  * The expected user data from Telegram.
@@ -18,4 +18,5 @@ export interface TelegramUserData {
 	is_bot?: boolean;
 	language_code?: string;
 	is_premium?: boolean;
+	allows_write_to_pm?: boolean;
 }


### PR DESCRIPTION
In the previous method, you had to json stringify the user object before sending the payload.
In the new version, you can send the payload as is.